### PR TITLE
fix(deps): update babel runtime and lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -844,12 +844,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
-      "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
-      "requires": {
-        "regenerator-runtime": "^0.13.2"
-      }
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
     },
     "@babel/template": {
       "version": "7.6.0",
@@ -6509,10 +6506,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "log-symbols": {
       "version": "3.0.0",
@@ -7840,11 +7836,6 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
       "version": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     ]
   },
   "dependencies": {
+    "@babel/runtime": "^7.29.2",
     "@hot-loader/react-dom": "^16.9.0",
     "@material-ui/core": "^4.4.3",
     "@material-ui/icons": "^4.4.3",
+    "lodash": "^4.18.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-hot-loader": "^4.12.14"


### PR DESCRIPTION
## Summary
- Supersedes Dependabot #32 and #34 with one owner branch to avoid lockfile conflicts.
- Updates `@babel/runtime` to 7.29.2 and `lodash` to 4.18.1.
- Keeps the existing ESLint 6 toolchain intact; #33 is not included because ESLint 10 breaks this repo's current `.eslintrc`/`eslint-loader` setup.

## Verification
- `npm install --package-lock-only --lockfile-version=1 @babel/runtime@7.29.2 lodash@4.18.1`
- `npm install --lockfile-version=1`
- `npm run lint`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`
- `npm run start -- --help`
- `git diff --check`

## Notes
- No hosted checks are configured for this repo.
- `NODE_OPTIONS=--openssl-legacy-provider` is still needed for webpack 4 under the current Node runtime.